### PR TITLE
Fix calibration freeze by async save

### DIFF
--- a/src/estivision/camera/frame_calibrator.py
+++ b/src/estivision/camera/frame_calibrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import queue
 from pathlib import Path
 from typing import List, Tuple
+from threading import Thread
 import cv2
 import numpy as np
 from PySide6.QtCore import QThread, Signal
@@ -109,15 +110,27 @@ class FrameCalibrator(QThread):
             self.failed.emit("キャリブレーションに失敗しました。")
             return
 
-        # --- キャリブレーション完了時の保存
-        np.savez(self._save_path, camera_matrix=mtx, dist_coeffs=dist, rvecs=rvecs, tvecs=tvecs, reprojection_error=ret)
-
-        self.finished.emit({
+        result = {
             "camera_matrix": mtx,
             "dist_coeffs": dist,
             "reprojection_error": ret,
             "file": str(self._save_path)
-        })
+        }
+        self.finished.emit(result)
+
+        # --- キャリブレーション結果を非同期保存
+        Thread(
+            target=np.savez,
+            args=(self._save_path,),
+            kwargs={
+                "camera_matrix": mtx,
+                "dist_coeffs": dist,
+                "rvecs": rvecs,
+                "tvecs": tvecs,
+                "reprojection_error": ret,
+            },
+            daemon=True,
+        ).start()
     # =====
 
     # ===== 停止要求 =====


### PR DESCRIPTION
## Summary
- avoid preview pause by saving calibration results asynchronously

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68810e80883c8329aef5b91e6689f5e1