### PR TITLE
Fix thread cleanup

### DIFF
--- a/src/estivision/gui/main_window.py
+++ b/src/estivision/gui/main_window.py
@@ -371,6 +371,9 @@ class MainWindow(QMainWindow):
         calib_btn.setEnabled(True)
 
         # --- ワーカ破棄
+        worker = getattr(self, worker_attr)
+        if worker:
+            worker.wait()
         setattr(self, worker_attr, None)
 
     def _on_calibration_failed(
@@ -392,6 +395,9 @@ class MainWindow(QMainWindow):
         calib_btn.setEnabled(True)
 
         # --- ワーカ破棄
+        worker = getattr(self, worker_attr)
+        if worker:
+            worker.wait()
         setattr(self, worker_attr, None)
 
     # --------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- ensure calibrator threads are completely stopped before releasing references

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812b0a608c8329b876b147fc54b192