### PR TITLE
Handle camera open failure

### DIFF
--- a/src/estivision/camera/camera_stream.py
+++ b/src/estivision/camera/camera_stream.py
@@ -14,6 +14,7 @@ class CameraStream(QThread):
     # --- GUI プレビュー／処理用シグナル
     image_ready: Signal = Signal(QImage)
     frame_ready: Signal = Signal(object)  # ndarray (BGR)
+    error: Signal = Signal(str)
 
     def __init__(self, device_id: int, fps: int = 30) -> None:
         """
@@ -32,6 +33,9 @@ class CameraStream(QThread):
         VideoCapture を開き、フレーム取得ループを回す。
         """
         cap = cv2.VideoCapture(self._device_id, cv2.CAP_DSHOW)
+        if not cap.isOpened():
+            self.error.emit("カメラを開けませんでした。")
+            return
 
         # --- カメラのデフォルト解像度
         default_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -49,9 +53,7 @@ class CameraStream(QThread):
         cap.set(cv2.CAP_PROP_FRAME_HEIGHT, target_h)
         cap.set(cv2.CAP_PROP_FPS,          self._fps)
 
-        self._running = cap.isOpened()
-        if not self._running:
-            return
+        self._running = True
 
         # --- 取得ループ
         while self._running:

--- a/src/estivision/gui/main_window.py
+++ b/src/estivision/gui/main_window.py
@@ -267,6 +267,7 @@ class MainWindow(QMainWindow):
         # --- 新ストリーム開始
         stream = CameraStream(device_id)
         stream.image_ready.connect(update_slot)
+        stream.error.connect(lambda msg, cid=cam_id: self._on_stream_error(cid, msg))
         stream.start()
         setattr(self, attr_stream, stream)
 
@@ -399,6 +400,15 @@ class MainWindow(QMainWindow):
         if worker:
             worker.wait()
         setattr(self, worker_attr, None)
+
+    def _on_stream_error(self, cam_id: int, message: str) -> None:
+        """CameraStream からのエラー受信時。"""
+        QMessageBox.critical(self, "カメラ接続失敗", message)
+        combo = self.camera1_combo if cam_id == 1 else self.camera2_combo
+        combo.blockSignals(True)
+        combo.setCurrentIndex(0)
+        combo.blockSignals(False)
+        self._on_camera_selected(cam_id, 0)
 
     # --------------------------------------------------------------------- #
     # UI ヘルパ                                                              #


### PR DESCRIPTION
## Summary
- emit an error signal from `CameraStream` when the camera fails to open
- connect the new signal in `MainWindow` and show an error dialog

## Testing
- `pytest -q`
- `python -m py_compile src/estivision/camera/camera_stream.py src/estivision/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_688191484734832985a7add3ec859908