### PR TITLE
Fix status label hidden after canceling calibration

### DIFF
--- a/src/estivision/gui/main_window.py
+++ b/src/estivision/gui/main_window.py
@@ -246,6 +246,7 @@ class MainWindow(QMainWindow):
         calib_btn.setEnabled(False)
         status_lbl.setText("未キャリブレーション")
         status_lbl.setStyleSheet(f"color: {WARNING_COLOR};")
+        status_lbl.setVisible(True)
 
         # --- 未選択
         if index == 0:


### PR DESCRIPTION
## Summary
- ensure calibration status label is made visible when camera selection is cleared

## Testing
- `pip install -r requirements.txt`
- `apt-get install -y libgl1 libegl1 libxkbcommon0 libpulse0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881980142488329b5ad54a31a0e26a5