### PR TITLE
Handle calibration interrupt

### DIFF
--- a/src/estivision/camera/frame_calibrator.py
+++ b/src/estivision/camera/frame_calibrator.py
@@ -100,6 +100,10 @@ class FrameCalibrator(QThread):
             self.preview.emit(qimg)
 
         if collected < self._samples:
+            # ウィンドウクローズによる停止など、割り込み要求が入った場合は
+            # エラー扱いとせず静かに終了する
+            if self.isInterruptionRequested():
+                return
             self.failed.emit("十分なサンプルが集まりませんでした。")
             return
 


### PR DESCRIPTION
## Summary
- avoid emitting calibration failure when interrupted

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68820792baa48329a8576b0d9442cbfe