### PR TITLE
Handle camera open failure

### DIFF
--- a/src/estivision/camera/camera_stream.py
+++ b/src/estivision/camera/camera_stream.py
@@ -34,6 +34,7 @@ class CameraStream(QThread):
         """
         cap = cv2.VideoCapture(self._device_id, cv2.CAP_DSHOW)
         if not cap.isOpened():
+            cap.release()
             self.error.emit("カメラを開けませんでした。")
             return
 


### PR DESCRIPTION
## Summary
- handle capture open failure by releasing `VideoCapture` and emitting error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882cf7c63788329a87e8c2470d42fe3