### PR TITLE
Add typing for safe_disconnect function

### DIFF
--- a/src/estivision/gui/main_window.py
+++ b/src/estivision/gui/main_window.py
@@ -1,5 +1,5 @@
 # ===== 標準ライブラリのインポート =====
-from typing import Tuple, List
+from typing import Tuple, List, Callable, Any
 from pathlib import Path
 # =====
 
@@ -29,7 +29,7 @@ from .safe_widgets import SafeComboBox
 # =====
 
 
-def safe_disconnect(signal, slot) -> None:
+def safe_disconnect(signal: object, slot: Callable[..., Any]) -> None:
     """Disconnect ``slot`` from ``signal`` ignoring any errors."""
     try:
         signal.disconnect(slot)


### PR DESCRIPTION
## Summary
- add `Callable` and `Any` import to support typing
- update `safe_disconnect` with parameter type hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d9daa30483298579f00a48ef4cee