### PR TITLE
Add pose preview worker and overlay toggle

### DIFF
--- a/src/estivision/gui/main_window.py
+++ b/src/estivision/gui/main_window.py
@@ -21,6 +21,7 @@ from .style_constants import (
 from ..camera.camera_manager import QtCameraManager
 from ..camera.camera_stream import CameraStream
 from ..camera.frame_calibrator import FrameCalibrator
+from ..pose.pose_preview_worker import PosePreviewWorker
 from .safe_widgets import SafeComboBox
 # ====
 
@@ -48,6 +49,7 @@ class MainWindow(QMainWindow):
         self.camera_widgets: dict[int, dict[str, object]] = {}
         self.streams: dict[int, CameraStream | None] = {1: None, 2: None}
         self.calib_workers: dict[int, FrameCalibrator | None] = {1: None, 2: None}
+        self.pose_workers: dict[int, PosePreviewWorker | None] = {1: None, 2: None}
         self.preview_slots: dict[int, Callable[[QImage], None]] = {}
 
         # --- UI 構築 ---
@@ -88,13 +90,14 @@ class MainWindow(QMainWindow):
         """カメラ 1・2 のプレビューグループを並べる。"""
         layout = QHBoxLayout()
         for cam_id in (1, 2):
-            grp, combo, label, calib_btn, status_lbl, progress = (
+            grp, combo, label, calib_btn, pose_btn, status_lbl, progress = (
                 self._create_camera_group(cam_id)
             )
             self.camera_widgets[cam_id] = {
                 "combo": combo,
                 "label": label,
                 "calib_btn": calib_btn,
+                "pose_btn": pose_btn,
                 "status": status_lbl,
                 "progress": progress,
             }
@@ -136,6 +139,13 @@ class MainWindow(QMainWindow):
             lambda _, cid=cam_id: self._on_calibration_start(cid)
         )
 
+        pose_btn = QPushButton("ポーズ表示")
+        pose_btn.setCheckable(True)
+        pose_btn.setEnabled(False)
+        pose_btn.toggled.connect(
+            lambda state, cid=cam_id: self._on_pose_toggled(cid, state)
+        )
+
         status_lbl = QLabel("未キャリブレーション")
         status_lbl.setAlignment(Qt.AlignCenter)
         status_lbl.setStyleSheet(f"color: {WARNING_COLOR};")
@@ -150,6 +160,7 @@ class MainWindow(QMainWindow):
         vbox.addWidget(combo)
         vbox.addWidget(label)
         vbox.addWidget(calib_btn)
+        vbox.addWidget(pose_btn)
         vbox.addWidget(status_lbl)
         vbox.addWidget(progress)
         vbox.setSizeConstraint(QLayout.SetFixedSize)
@@ -157,7 +168,7 @@ class MainWindow(QMainWindow):
 
         group = QGroupBox(f"Camera {cam_id}")
         group.setLayout(vbox)
-        return group, combo, label, calib_btn, status_lbl, progress
+        return group, combo, label, calib_btn, pose_btn, status_lbl, progress
 
     def _make_qimage_updater(self, label: QLabel) -> Callable[[QImage], None]:
         """QImage をラベルへ描画するコールバックを生成。"""
@@ -199,12 +210,24 @@ class MainWindow(QMainWindow):
         update_slot = self.preview_slots[cam_id]
         stream: CameraStream | None = self.streams[cam_id]
         worker: FrameCalibrator | None = self.calib_workers[cam_id]
+        pose_worker: PosePreviewWorker | None = self.pose_workers[cam_id]
+        pose_btn: QPushButton = widgets.get("pose_btn")  # type: ignore[index]
 
         # --- 既存ストリーム停止 ---
         if stream:
             safe_disconnect(stream.image_ready, update_slot)
             stream.stop()
             self.streams[cam_id] = None
+
+        if pose_worker:
+            if stream:
+                safe_disconnect(stream.frame_ready, pose_worker.enqueue_frame)
+            safe_disconnect(pose_worker.preview, update_slot)
+            pose_worker.stop()
+            self.pose_workers[cam_id] = None
+        if pose_btn:
+            pose_btn.setChecked(False)
+            pose_btn.setEnabled(False)
 
         # --- キャリブレーションワーカ停止 ---
         if worker:
@@ -281,6 +304,7 @@ class MainWindow(QMainWindow):
 
         stream = self.streams[cam_id]
         worker = self.calib_workers[cam_id]
+        pose_btn: QPushButton = widgets["pose_btn"]  # type: ignore[index]
         update_slot = self.preview_slots[cam_id]
 
         if combo.currentIndex() == 0:
@@ -290,6 +314,8 @@ class MainWindow(QMainWindow):
             return
 
         calib_btn.setEnabled(False)
+        if pose_btn.isChecked():
+            pose_btn.setChecked(False)
         status_lbl.setVisible(False)
         progress.setValue(0)
         progress.setVisible(True)
@@ -335,6 +361,11 @@ class MainWindow(QMainWindow):
 
         calib_btn.setEnabled(True)
 
+        pose_btn: QPushButton = widgets["pose_btn"]  # type: ignore[index]
+        if not self.pose_workers[cam_id]:
+            self.pose_workers[cam_id] = PosePreviewWorker()
+        pose_btn.setEnabled(True)
+
         worker = self.calib_workers[cam_id]
         if worker:
             worker.wait()
@@ -358,6 +389,27 @@ class MainWindow(QMainWindow):
         if worker:
             worker.wait()
         self.calib_workers[cam_id] = None
+
+    def _on_pose_toggled(self, cam_id: int, checked: bool) -> None:
+        """Pose overlay toggle handler."""
+        widgets = self.camera_widgets[cam_id]
+        pose_btn: QPushButton = widgets["pose_btn"]  # type: ignore[index]
+        stream = self.streams[cam_id]
+        worker = self.pose_workers.get(cam_id)
+        update_slot = self.preview_slots[cam_id]
+        if not worker or not stream:
+            pose_btn.setChecked(False)
+            return
+        if checked:
+            safe_disconnect(stream.image_ready, update_slot)
+            stream.frame_ready.connect(worker.enqueue_frame)
+            worker.preview.connect(update_slot)
+            if not worker.isRunning():
+                worker.start()
+        else:
+            safe_disconnect(stream.frame_ready, worker.enqueue_frame)
+            safe_disconnect(worker.preview, update_slot)
+            stream.image_ready.connect(update_slot)
 
     def _on_stream_error(self, cam_id: int, message: str) -> None:
         """CameraStream からのエラー受信時。"""
@@ -422,5 +474,9 @@ class MainWindow(QMainWindow):
             if worker:
                 worker.requestInterruption()
                 worker.stop()
+
+        for pworker in self.pose_workers.values():
+            if pworker:
+                pworker.stop()
 
         super().closeEvent(event)

--- a/src/estivision/pose/__init__.py
+++ b/src/estivision/pose/__init__.py
@@ -1,3 +1,6 @@
 """pose サブパッケージの公開 API。"""
 from .pose_estimator import PoseEstimator  # re-export
-__all__ = ["PoseEstimator"]
+from .pose_preview_worker import PosePreviewWorker
+from .drawing import draw_pose
+
+__all__ = ["PoseEstimator", "PosePreviewWorker", "draw_pose"]

--- a/src/estivision/pose/drawing.py
+++ b/src/estivision/pose/drawing.py
@@ -1,0 +1,52 @@
+"""Pose drawing utilities."""
+
+# ===== インポート =====
+import cv2 as cv
+import numpy as np
+# ====
+
+
+# --- 骨格接続ペア (MoveNet Keypoint Index) ---
+_SKELETON: list[tuple[int, int]] = [
+    (0, 1), (0, 2), (1, 3), (2, 4),
+    (0, 5), (0, 6), (5, 7), (7, 9),
+    (6, 8), (8, 10), (5, 6), (5, 11),
+    (6, 12), (11, 12), (11, 13),
+    (13, 15), (12, 14), (14, 16),
+]
+# --- 骨格ごとに色を設定 ---
+_SKELETON_COLORS: list[tuple[int, int, int]] = [
+    (255, 0, 85),
+    (255, 0, 0),
+    (255, 85, 0),
+    (255, 170, 0),
+    (255, 255, 0),
+    (170, 255, 0),
+    (85, 255, 0),
+    (0, 255, 0),
+    (0, 255, 85),
+    (0, 255, 170),
+    (0, 255, 255),
+    (0, 170, 255),
+    (0, 85, 255),
+    (0, 0, 255),
+    (85, 0, 255),
+    (170, 0, 255),
+    (255, 0, 255),
+]
+
+
+def draw_pose(img: np.ndarray, kps: np.ndarray, scores: np.ndarray, thr: float = 0.2) -> np.ndarray:
+    """Return an image with pose skeleton drawn."""
+    disp = img.copy()
+    for i, (p1, p2) in enumerate(_SKELETON):
+        if scores[p1] > thr and scores[p2] > thr:
+            color = _SKELETON_COLORS[i % len(_SKELETON_COLORS)]
+            cv.line(disp, tuple(kps[p1]), tuple(kps[p2]), color, 2)
+    for (x, y), s in zip(kps, scores):
+        if s > thr:
+            cv.circle(disp, (int(x), int(y)), 5, (0, 0, 0), -1)
+            cv.circle(disp, (int(x), int(y)), 3, (255, 255, 255), -1)
+    return disp
+
+__all__ = ["draw_pose"]

--- a/src/estivision/pose/pose_preview_worker.py
+++ b/src/estivision/pose/pose_preview_worker.py
@@ -1,0 +1,72 @@
+"""Worker thread for pose overlay preview."""
+
+# ===== インポート =====
+from __future__ import annotations
+import queue
+from pathlib import Path
+from typing import List
+
+import cv2 as cv
+import numpy as np
+from PySide6.QtCore import QObject, QThread, Signal
+from PySide6.QtGui import QImage
+
+from .pose_estimator import PoseEstimator
+from .drawing import draw_pose
+# ====
+
+
+class PosePreviewWorker(QThread):
+    """Receive frames and emit pose overlay images."""
+
+    preview: Signal = Signal(QImage)
+
+    def __init__(
+        self,
+        model_type: str = "lightning",
+        *,
+        model_dir: Path | None = None,
+        providers: List[str] | None = None,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._queue: "queue.Queue[np.ndarray]" = queue.Queue(maxsize=5)
+        self._running = False
+        self._estimator = PoseEstimator(
+            model_type=model_type,
+            model_dir=model_dir,
+            providers=providers,
+        )
+
+    def enqueue_frame(self, frame: np.ndarray) -> None:
+        """Receive frame from CameraStream."""
+        if not self._running:
+            return
+        try:
+            self._queue.put_nowait(frame)
+        except queue.Full:
+            self._queue.get_nowait()
+            self._queue.put_nowait(frame)
+
+    def run(self) -> None:  # noqa: D401
+        """Main loop processing frames."""
+        self._running = True
+        while self._running:
+            try:
+                frame = self._queue.get(timeout=1.0)
+            except queue.Empty:
+                continue
+            if self.isInterruptionRequested():
+                break
+            kps, scores = self._estimator.estimate(frame)
+            drawn = draw_pose(frame, kps, scores)
+            rgb = cv.cvtColor(drawn, cv.COLOR_BGR2RGB)
+            h, w, _ = rgb.shape
+            qimg = QImage(rgb.data, w, h, 3 * w, QImage.Format.Format_RGB888)
+            self.preview.emit(qimg)
+
+    def stop(self) -> None:
+        """Stop worker thread."""
+        self._running = False
+        self.requestInterruption()
+        self.wait()

--- a/tests/test_pose_image.py
+++ b/tests/test_pose_image.py
@@ -9,53 +9,8 @@ import pytest
 
 # --- 自作モジュール ---
 from estivision.pose.pose_estimator import PoseEstimator
+from estivision.pose.drawing import draw_pose
 # ====
-
-
-# ===== 定数定義 =====
-# --- 骨格接続ペア (MoveNet Keypoint Index) ---
-_SKELETON: list[tuple[int, int]] = [
-    (0, 1), (0, 2), (1, 3), (2, 4),
-    (0, 5), (0, 6), (5, 7), (7, 9),
-    (6, 8), (8, 10), (5, 6), (5, 11),
-    (6, 12), (11, 12), (11, 13),
-    (13, 15), (12, 14), (14, 16),
-]
-# --- 骨格ごとに色を設定 ---
-_SKELETON_COLORS: list[tuple[int, int, int]] = [
-    (255, 0, 85),     # 鼻～首（ピンク系）
-    (255, 0, 0),      # 右目～鼻
-    (255, 85, 0),     # 左目～鼻
-    (255, 170, 0),    # 右耳～右目
-    (255, 255, 0),    # 左耳～左目
-    (170, 255, 0),    # 首～右肩
-    (85, 255, 0),     # 首～左肩
-    (0, 255, 0),      # 右肩～右肘
-    (0, 255, 85),     # 左肩～左肘
-    (0, 255, 170),    # 右肘～右手首
-    (0, 255, 255),    # 左肘～左手首
-    (0, 170, 255),    # 首～右腰
-    (0, 85, 255),     # 首～左腰
-    (0, 0, 255),      # 右腰～右膝
-    (85, 0, 255),     # 左腰～左膝
-    (170, 0, 255),    # 右膝～右足首
-    (255, 0, 255),    # 左膝～左足首
-]
-# ====
-
-
-def _draw_pose(img: np.ndarray, kps: np.ndarray, scores: np.ndarray, thr: float = 0.2) -> np.ndarray:
-    """骨格・キーポイントを描画。"""
-    disp = img.copy()
-    for i, (p1, p2) in enumerate(_SKELETON):
-        if scores[p1] > thr and scores[p2] > thr:
-            color = _SKELETON_COLORS[i % len(_SKELETON_COLORS)]
-            cv.line(disp, tuple(kps[p1]), tuple(kps[p2]), color, 2)
-    for (x, y), s in zip(kps, scores):
-        if s > thr:
-            cv.circle(disp, (int(x), int(y)), 5, (0, 0, 0), -1)      # 黒縁
-            cv.circle(disp, (int(x), int(y)), 3, (255, 255, 255), -1)  # 白丸
-    return disp
 
 # --- テスト用フィクスチャ ---
 @pytest.fixture(scope="module")
@@ -101,7 +56,7 @@ def test_draw_and_save(estimator: PoseEstimator) -> None:
     img = cv.imread(asset_jpg.as_posix()) if asset_jpg.is_file() else np.zeros((480, 640, 3), np.uint8)
 
     kps, scores = estimator.estimate(img)
-    drawn = _draw_pose(img, kps, scores)
+    drawn = draw_pose(img, kps, scores)
     out_path = asset_dir.joinpath("pose_result.png")
     cv.imwrite(out_path.as_posix(), drawn)
     assert out_path.is_file()

--- a/tests/test_pose_video.py
+++ b/tests/test_pose_video.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # ===== 自作モジュールのインポート =====
 from estivision.pose.pose_estimator import PoseEstimator
-from test_pose_image import _draw_pose
+from estivision.pose.drawing import draw_pose
 
 # ===== 設定 =====
 VIDEO_PATH = "tests/assets/example.mp4"       # 入力動画ファイル
@@ -64,4 +64,4 @@ if __name__ == "__main__":
         providers=["CPUExecutionProvider"]
     )
     # 動画処理
-    process_video(VIDEO_PATH, OUT_PATH, estimator, _draw_pose)
+    process_video(VIDEO_PATH, OUT_PATH, estimator, draw_pose)

--- a/tests/test_pose_worker.py
+++ b/tests/test_pose_worker.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtTest import QTest
+from PySide6.QtGui import QImage
+
+from estivision.pose.pose_preview_worker import PosePreviewWorker
+
+
+@pytest.fixture(scope="module")
+def app() -> QCoreApplication:  # type: ignore[override]
+    return QCoreApplication([])
+
+
+def test_pose_preview_worker_basic(app: QCoreApplication) -> None:
+    model_path = Path("data/models/movenet_singlepose_lightning_v4.onnx")
+    if not model_path.is_file():
+        pytest.skip("モデルが見つからないためスキップ")
+
+    worker = PosePreviewWorker(
+        model_type="lightning",
+        model_dir=model_path.parent,
+        providers=["CPUExecutionProvider"],
+    )
+    results: list[QImage] = []
+    worker.preview.connect(lambda img: results.append(img))
+    worker.start()
+    dummy = np.zeros((480, 640, 3), np.uint8)
+    for _ in range(3):
+        worker.enqueue_frame(dummy)
+        QTest.qWait(100)
+    worker.stop()
+    assert results and all(isinstance(r, QImage) for r in results)
+


### PR DESCRIPTION
## Summary
- add drawing helpers for pose skeletons
- implement `PosePreviewWorker` for threaded pose overlay
- integrate pose preview into `MainWindow` with toggle button
- expose new utilities via `estivision.pose`
- update tests and add `test_pose_worker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884889a38c48329a12732f66ec6529d